### PR TITLE
Update SysUiOverlay.java

### DIFF
--- a/com/android/layoutlib/bridge/impl/SysUiOverlay.java
+++ b/com/android/layoutlib/bridge/impl/SysUiOverlay.java
@@ -57,7 +57,7 @@ class SysUiOverlay extends View {
 
 
     private static float dpToPx(DisplayMetrics metrics, float value) {
-        return TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_PX, value, metrics);
+        return TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, value, metrics);
     }
 
 


### PR DESCRIPTION
dpToPx need use TypedValue.COMPLEX_UNIT_DIP

[issues 1](https://github.com/AndroidSDKSources/android-sdk-sources-for-api-level-29/issues/1)
https://github.com/AndroidSDKSources/android-sdk-sources-for-api-level-29/blob/815d70abfebfcd8a80015c9da50e8a76c12bba2b/com/android/layoutlib/bridge/impl/SysUiOverlay.java#L60

line 59:
```java
    private static float dpToPx(DisplayMetrics metrics, float value) {
        return TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_PX, value, metrics);
    }
```

SysUiOverlay class dpToPx method have a problem
> this method is dpTopx method, need use `TypedValue.COMPLEX_UNIT_DIP` not `TypedValue.COMPLEX_UNIT_PX` because dp to px need dp*density

applyDimension source:
```java
public static float applyDimension(int unit, float value,
                                       DisplayMetrics metrics)
    {
        switch (unit) {
        case COMPLEX_UNIT_PX:
            return value;
        case COMPLEX_UNIT_DIP:
            return value * metrics.density;
        case COMPLEX_UNIT_SP:
            return value * metrics.scaledDensity;
        case COMPLEX_UNIT_PT:
            return value * metrics.xdpi * (1.0f/72);
        case COMPLEX_UNIT_IN:
            return value * metrics.xdpi;
        case COMPLEX_UNIT_MM:
            return value * metrics.xdpi * (1.0f/25.4f);
        }
        return 0;
    }
```

so this method should be
```java
    private static float dpToPx(DisplayMetrics metrics, float value) {
        return TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, value, metrics);
    }
```

> com.google.android.material.internal.ViewUtils dpToPx method is right
```java
  public static float dpToPx(@NonNull Context context, @Dimension(unit = Dimension.DP) int dp) {
    Resources r = context.getResources();
    return TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, dp, r.getDisplayMetrics());
  }
```
I don't know why you guys wrote it wrong
have a good day!


